### PR TITLE
Improve performance

### DIFF
--- a/src/ncdiff/__init__.py
+++ b/src/ncdiff/__init__.py
@@ -4,7 +4,7 @@ payload of a Netconf get-config reply, and a diff is the payload of a
 edit-config message."""
 
 # metadata
-__version__ = '2.1.3'
+__version__ = '2.1.4'
 __author__ = 'Jonathan Yang <yuekyang@cisco.com>'
 __contact__ = 'yang-python@cisco.com'
 __copyright__ = 'Cisco Systems, Inc.'

--- a/src/ncdiff/calculator.py
+++ b/src/ncdiff/calculator.py
@@ -161,14 +161,16 @@ class BaseCalculator(object):
         for child in node_one.getchildren():
             key = build_unique_id(child)
             if key in ones:
-                raise Exception()
+                raise ConfigError('not unique peer of node {} {}' \
+                    .format(child, ones[key]))
             ones[key] = child
 
         twos = {}
         for child in node_two.getchildren():
             key = build_unique_id(child)
             if key in twos:
-                raise Exception()
+                raise ConfigError('not unique peer of node {} {}' \
+                                  .format(child, twos[key]))
             twos[key] = child
 
         return [(ones.get(uid, None), twos.get(uid, None)) for uid in set(ones.keys()).union(set(twos.keys()))]

--- a/src/ncdiff/calculator.py
+++ b/src/ncdiff/calculator.py
@@ -110,8 +110,8 @@ class BaseCalculator(object):
         return [child for child in parent.iterchildren(tag=tag)
                 if child in new_scope]
 
-    def _pair_childern(self, node_one, node_two):
-        """_pair_childern
+    def _pair_children(self, node_one, node_two):
+        """_pair_children
          pair all children with their peers, resulting in a list of Tuples
 
          Parameters
@@ -248,7 +248,7 @@ class BaseCalculator(object):
         in_2_not_in_1 = []
         in_1_and_in_2 = []
 
-        for one, two in self._pair_childern(node_one, node_two):
+        for one, two in self._pair_children(node_one, node_two):
             if one is None:
                 in_2_not_in_1.append(two)
             elif two is None:
@@ -519,7 +519,7 @@ class BaseCalculator(object):
             if a not in node_other.attrib or \
                node_self.attrib[a] != node_other.attrib[a]:
                 return False
-        for child, child_other in self._pair_childern(node_self, node_other):
+        for child, child_other in self._pair_children(node_self, node_other):
             if child is None:
                 # only in other, meaningless
                 continue

--- a/src/ncdiff/calculator.py
+++ b/src/ncdiff/calculator.py
@@ -1,4 +1,6 @@
 import logging
+from functools import lru_cache
+
 from ncclient import xml_
 
 from .ref import IdentityRef, InstanceIdentifier
@@ -108,6 +110,70 @@ class BaseCalculator(object):
         return [child for child in parent.iterchildren(tag=tag)
                 if child in new_scope]
 
+    def _pair_childern(self, node_one, node_two):
+        # construct correctly keyed dict, for node_one:
+        # keys are (tag, self-key)
+        # self key is
+        #    text for leaf-list
+        #    key tuple for list
+        #    none for others
+
+        def find_one_child(node, tag):
+            s = list(node.iterchildren(tag=tag))
+            if len(s) < 1:
+                raise ConfigError("cannot find key '{}' in node {}" \
+                                  .format(tag,
+                                          self.device.get_xpath(node)))
+            if len(s) > 1:
+                raise ConfigError("not unique key '{}' in node {}" \
+                                  .format(tag,
+                                          self.device.get_xpath(node)))
+            return s[0]
+
+        def build_index_tuple(node, keys, s_node):
+            out = [self._parse_text(find_one_child(node, k), s_node) for k in keys]
+            return tuple(out)
+
+        type_for_tag = {}
+        def get_type_for_tag(tag, child):
+            node_type = type_for_tag.get(tag, None)
+            if node_type is not None:
+                return node_type
+            s_node = self.device.get_schema_node(child)
+            node_type = s_node.get('type')
+
+            result = (s_node, node_type)
+            type_for_tag[tag] = result
+            return result
+
+        def build_unique_id(child):
+            tag = child.tag
+            key = None
+            s_node, node_type = get_type_for_tag(tag, child)
+            if node_type == 'leaf-list':
+                key = self._parse_text(child, s_node)
+            elif node_type == 'list':
+                keys = self._get_list_keys(s_node)
+                key = build_index_tuple(child, keys, s_node)
+            return (tag, key)
+
+        ones = {}
+        for child in node_one.getchildren():
+            key = build_unique_id(child)
+            if key in ones:
+                raise Exception()
+            ones[key] = child
+
+        twos = {}
+        for child in node_two.getchildren():
+            key = build_unique_id(child)
+            if key in twos:
+                raise Exception()
+            twos[key] = child
+
+        return [(ones.get(uid, None), twos.get(uid, None)) for uid in set(ones.keys()).union(set(twos.keys()))]
+
+
     def _group_kids(self, node_one, node_two):
         '''_group_kids
 
@@ -140,30 +206,15 @@ class BaseCalculator(object):
         in_1_not_in_2 = []
         in_2_not_in_1 = []
         in_1_and_in_2 = []
-        for child in node_one.getchildren():
-            peers = self._get_peers(child, node_two)
-            if len(peers) < 1:
-                # child in self but not in other
-                in_1_not_in_2.append(child)
-            elif len(peers) > 1:
-                # one child in self matches multiple children in other
-                raise ConfigError('not unique peer of node {}' \
-                                  .format(self.device.get_xpath(child)))
+
+        for one, two in self._pair_childern(node_one, node_two):
+            if one is None:
+                in_2_not_in_1.append(two)
+            elif two is None:
+                in_1_not_in_2.append(one)
             else:
-                # child matches one peer in other
-                in_1_and_in_2.append((child, peers[0]))
-        for child in node_two.getchildren():
-            peers = self._get_peers(child, node_one)
-            if len(peers) < 1:
-                # child in other but not in self
-                in_2_not_in_1.append(child)
-            elif len(peers) > 1:
-                # one child in other matches multiple children in self
-                raise ConfigError('not unique peer of node {}' \
-                                  .format(self.device.get_xpath(child)))
-            else:
-                # child in self matches one peer in self
-                pass
+                in_1_and_in_2.append((one, two))
+
         return (in_1_not_in_2, in_2_not_in_1, in_1_and_in_2)
 
     @staticmethod
@@ -188,7 +239,7 @@ class BaseCalculator(object):
 
         nodes = list(filter(lambda x: x.get('is_key'),
                             schema_node.getchildren()))
-        return [n.tag for n in nodes]
+        return sorted([n.tag for n in nodes])
 
     def _get_peers(self, child_self, parent_other):
         '''_get_peers
@@ -265,7 +316,8 @@ class BaseCalculator(object):
                 return False
         return True
 
-    def _parse_text(self, node):
+    @lru_cache(maxsize=1024)
+    def _parse_text(self, node, schema_node=None):
         '''_parse_text
 
         Low-level api: Return text if a node. Pharsing is required if the node
@@ -287,7 +339,9 @@ class BaseCalculator(object):
 
         if node.text is None:
             return None
-        schema_node = self.device.get_schema_node(node)
+
+        if schema_node is None:
+            schema_node = self.device.get_schema_node(node)
         if schema_node.get('datatype') is not None and \
           (schema_node.get('datatype')[:11] == 'identityref' or schema_node.get('datatype')[:3] == '-> '):
             idref = IdentityRef(self.device, node)
@@ -423,38 +477,39 @@ class BaseCalculator(object):
             if a not in node_other.attrib or \
                node_self.attrib[a] != node_other.attrib[a]:
                 return False
-        for child in node_self.getchildren():
-            peers = self._get_peers(child, node_other)
-            if len(peers) < 1:
+        for child, child_other in self._pair_childern(node_self, node_other):
+            if child is None:
+                # only in other, meaningless
+                continue
+            if child_other is None:
+                # only in other, false
                 return False
-            elif len(peers) > 1:
-                raise ConfigError('not unique peer of node {}' \
-                                  .format(self.device.get_xpath(child)))
-            else:
-                schma_node = self.device.get_schema_node(child)
-                if schma_node.get('ordered-by') == 'user' and \
-                   schma_node.get('type') == 'leaf-list' or \
-                   schma_node.get('ordered-by') == 'user' and \
-                   schma_node.get('type') == 'list':
-                    elder_siblings = list(child.itersiblings(tag=child.tag,
-                                                             preceding=True))
-                    if elder_siblings:
-                        immediate_elder_sibling = elder_siblings[0]
-                        peers_of_immediate_elder_sibling = \
-                            self._get_peers(immediate_elder_sibling,
-                                            node_other)
-                        if len(peers_of_immediate_elder_sibling) < 1:
-                            return False
-                        elif len(peers_of_immediate_elder_sibling) > 1:
-                            p = self.device.get_xpath(immediate_elder_sibling)
-                            raise ConfigError('not unique peer of node {}' \
-                                              .format(p))
-                        elder_siblings_of_peer = \
-                            list(peers[0].itersiblings(tag=child.tag,
-                                                       preceding=True))
-                        if peers_of_immediate_elder_sibling[0] not in \
-                           elder_siblings_of_peer:
-                            return False
-                if not self._node_le(child, peers[0]):
-                    return False
+            # both are present
+            schma_node = self.device.get_schema_node(child)
+            if schma_node.get('ordered-by') == 'user' and \
+                    schma_node.get('type') == 'leaf-list' or \
+                    schma_node.get('ordered-by') == 'user' and \
+                    schma_node.get('type') == 'list':
+                elder_siblings = list(child.itersiblings(tag=child.tag,
+                                                         preceding=True))
+                if elder_siblings:
+                    immediate_elder_sibling = elder_siblings[0]
+                    peers_of_immediate_elder_sibling = \
+                        self._get_peers(immediate_elder_sibling,
+                                        node_other)
+                    if len(peers_of_immediate_elder_sibling) < 1:
+                        return False
+                    elif len(peers_of_immediate_elder_sibling) > 1:
+                        p = self.device.get_xpath(immediate_elder_sibling)
+                        raise ConfigError('not unique peer of node {}' \
+                                          .format(p))
+                    elder_siblings_of_peer = \
+                        list(child_other.itersiblings(tag=child.tag,
+                                                   preceding=True))
+                    if peers_of_immediate_elder_sibling[0] not in \
+                            elder_siblings_of_peer:
+                        return False
+            if not self._node_le(child, child_other):
+                return False
+
         return True

--- a/src/ncdiff/config.py
+++ b/src/ncdiff/config.py
@@ -78,7 +78,7 @@ class Config(object):
             raise TypeError("argument 'config' must be None, XML string, " \
                             "or Element, but not '{}'" \
                             .format(type(config)))
-        self.validate_config()
+        #self.validate_config()
 
     def __repr__(self):
         return '<{}.{} {} at {}>'.format(self.__class__.__module__,

--- a/src/ncdiff/config.py
+++ b/src/ncdiff/config.py
@@ -58,7 +58,7 @@ class Config(object):
         `{url}tagname` notation, and values are corresponding model names.
     '''
 
-    def __init__(self, ncdevice, config=None):
+    def __init__(self, ncdevice, config=None, validate=True):
         '''
         __init__ instantiates a Config instance.
         '''
@@ -78,7 +78,8 @@ class Config(object):
             raise TypeError("argument 'config' must be None, XML string, " \
                             "or Element, but not '{}'" \
                             .format(type(config)))
-        #self.validate_config()
+        if validate:
+            self.validate_config()
 
     def __repr__(self):
         return '<{}.{} {} at {}>'.format(self.__class__.__module__,
@@ -92,7 +93,7 @@ class Config(object):
                               pretty_print=True)
 
     def __bool__(self):
-        d = Config(self.device, None)
+        d = Config(self.device, None, False)
         if self == d:
             return False
         else:
@@ -103,21 +104,21 @@ class Config(object):
             if ConfigCompatibility(self, other).is_compatible:
                 return Config(self.device,
                               NetconfCalculator(self.device,
-                                                self.ele, other.ele).add)
+                                                self.ele, other.ele).add, False)
         elif isinstance(other, ConfigDelta):
             if ConfigCompatibility(self, other).is_compatible:
                 return Config(self.device,
                               NetconfCalculator(self.device,
-                                                self.ele, other.nc).add)
+                                                self.ele, other.nc).add, False)
         elif etree.iselement(other):
             return Config(self.device,
-                          NetconfCalculator(self.device, self.ele, other).add)
+                          NetconfCalculator(self.device, self.ele, other).add, False)
         elif isinstance(other, Request):
             return Config(self.device,
-                          RestconfCalculator(self.device, self.ele, other).add)
+                          RestconfCalculator(self.device, self.ele, other).add, False)
         elif isinstance(other, SetRequest):
             return Config(self.device,
-                          gNMICalculator(self.device, self.ele, other).add)
+                          gNMICalculator(self.device, self.ele, other).add, False)
         else:
             return NotImplemented
 

--- a/src/ncdiff/manager.py
+++ b/src/ncdiff/manager.py
@@ -1,5 +1,7 @@
 import os
 import re
+from functools import lru_cache
+
 import six
 import logging
 from lxml import etree
@@ -112,6 +114,7 @@ class ModelDevice(manager.Manager):
                                              hex(id(self)))
 
     @property
+    @lru_cache(maxsize=1)
     def namespaces(self):
         if self.compiler is None:
             raise ValueError('please first call scan_models() to build ' \

--- a/src/ncdiff/manager.py
+++ b/src/ncdiff/manager.py
@@ -115,6 +115,7 @@ class ModelDevice(manager.Manager):
 
     @property
     @lru_cache(maxsize=1)
+    # extremely expensive call, cache
     def namespaces(self):
         if self.compiler is None:
             raise ValueError('please first call scan_models() to build ' \

--- a/src/ncdiff/manager.py
+++ b/src/ncdiff/manager.py
@@ -573,10 +573,11 @@ class ModelDevice(manager.Manager):
             return True
 
         n = Composer(self, config_node)
-        config_path_str = ' '.join(n.path)
+        path = n.path
+        config_path_str = ' '.join(path)
         if config_path_str in self.nodes:
             return self.nodes[config_path_str]
-        if len(n.path) > 1:
+        if len(path) > 1:
             parent = self.get_schema_node(config_node.getparent())
             child = get_child(parent, config_node.tag)
             if child is None:

--- a/src/ncdiff/netconf.py
+++ b/src/ncdiff/netconf.py
@@ -754,14 +754,14 @@ class NetconfCalculator(BaseCalculator):
             list_other = [c for c in list(node_other) if c.tag == tag]
             s_node = self.device.get_schema_node((list_self + list_other)[0])
             if s_node.get('ordered-by') == 'user':
-                if [self._parse_text(i) for i in list_self] == \
-                   [self._parse_text(i) for i in list_other]:
+                if [self._parse_text(i, s_node) for i in list_self] == \
+                   [self._parse_text(i, s_node) for i in list_other]:
                     return True
                 else:
                     return False
             else:
-                if set([self._parse_text(i) for i in list_self]) == \
-                   set([self._parse_text(i) for i in list_other]):
+                if set([self._parse_text(i, s_node) for i in list_self]) == \
+                   set([self._parse_text(i, s_node) for i in list_other]):
                     return True
                 else:
                     return False


### PR DESCRIPTION
For larger configs, ncdiff is quite slow. 

This pull request improves performance for medium sized configs by a factor of 8.
An example test improved from 31s to 4s (see below).

I optimized the following points: 
- cache important calls
- reduce time complexity of peer matching from O(n^2) to O(n)
- remove validation of constructed configs

The optimization is quite opportunistic to my case and could be further extended.

![image](https://user-images.githubusercontent.com/1788254/82916607-8b471100-9f72-11ea-897b-a63fe02d0670.png)
