### PR TITLE
Remove whitespace from containers

### DIFF
--- a/src/ncdiff/calculator.py
+++ b/src/ncdiff/calculator.py
@@ -297,6 +297,9 @@ class BaseCalculator(object):
             instanceid = InstanceIdentifier(self.device, node)
             return instanceid.default
         else:
+            if schema_node.get("type") == "container":
+                # prevent whitespace in container to cause problems
+                return None
             return node.text
 
     def _same_text(self, node1, node2):


### PR DESCRIPTION
fixes #4

A check is added that any Element with a 'Container' type in yang, that contains only whitespace, is considered to be empty.

Perhaps the emptiness check is not needed, my knowledge of the standard is not that good, so I erred at the safe side.

I also have some testcases, but they are against Nokia devices and require the Yang models found at https://github.com/nokia/7x50_YangModels/tree/master/latest_sros_19.10. So I did not add them to the PR.