### PR TITLE
Remove memory leak introduced in #2

### DIFF
--- a/src/ncdiff/manager.py
+++ b/src/ncdiff/manager.py
@@ -1,6 +1,5 @@
 import os
 import re
-from functools import lru_cache
 
 import six
 import logging
@@ -107,6 +106,7 @@ class ModelDevice(manager.Manager):
         self.nodes = {}
         self.compiler = None
         self._models_loadable = None
+        self.namespaces_cache = None
 
     def __repr__(self):
         return '<{}.{} object at {}>'.format(self.__class__.__module__,
@@ -114,9 +114,10 @@ class ModelDevice(manager.Manager):
                                              hex(id(self)))
 
     @property
-    @lru_cache(maxsize=1)
     # extremely expensive call, cache
     def namespaces(self):
+        if self.namespaces_cache is not None:
+            return self.namespaces_cache
         if self.compiler is None:
             raise ValueError('please first call scan_models() to build ' \
                              'up supported namespaces of a device')
@@ -126,6 +127,7 @@ class ModelDevice(manager.Manager):
                 device_namespaces.append((m.get('id'),
                                           m.get('prefix'),
                                           m.findtext('namespace')))
+            self.namespaces_cache = device_namespaces
             return device_namespaces
 
     @property


### PR DESCRIPTION
Hi all, 

In #2 I introduced caches to improve performance. 
We have discovered that these caches introduce memory leaks.

Hereby a patch to fix this leak. 

# Details

- the functools.lru_cache locks all arguments and return value of the method it caches in memory 
- this includes the 'self' reference. 

We also filed a bug for this on python: https://bugs.python.org/issue44310

# Backstory

- On devices with a large yang schema, we observed consistent growth of the memory footprint
- We spent several days searching for the cause, this was complicated by the complex interaction between lxml/libxml2 (which is written in C) and glibc  (documented here, bottom of the page:  http://xmlsoft.org/xmlmem.html) .
- We eventually discovered that the functools.lru_cache locks arguments in memory, using objgraph