### PR TITLE
Improved handling of cache corruption

### DIFF
--- a/src/ncdiff/model.py
+++ b/src/ncdiff/model.py
@@ -628,12 +628,16 @@ class ModelCompiler(object):
         self.build_dependencies()
 
     def _xml_from_cache(self, name):
-        cached_name = os.path.join(self.dir_yang, f"{name}.xml")
-        if os.path.exists(cached_name):
-            with(open(cached_name, "r", encoding="utf-8")) as fh:
-                parser = etree.XMLParser(remove_blank_text=True)
-                tree = etree.XML(fh.read(), parser)
-                return tree
+        try:
+            cached_name = os.path.join(self.dir_yang, f"{name}.xml")
+            if os.path.exists(cached_name):
+                with(open(cached_name, "r", encoding="utf-8")) as fh:
+                    parser = etree.XMLParser(remove_blank_text=True)
+                    tree = etree.XML(fh.read(), parser)
+                    return tree
+        except Exception:
+            # make the cache safe: any failure will just bypass the cache
+            logger.info(f"Unexpected failure during cache read of {name}, refreshing cache", exc_info=True)
         return None
 
     def _to_cache(self, name, value):


### PR DESCRIPTION
This pull request improves the resilience against cache corruption.

I introduced the cache in https://github.com/CiscoTestAutomation/ncdiff/pull/2.

We recently discovered that when the cache becomes corrupt, this can cause failures.
This PR makes these failures into cache refreshes. 

```
  File "/var/lib/inmanta/cf32fa4e-c9e3-41d9-a136-2e37c58c5b46/agent/env/lib/python3.9/site-packages/ncdiff/manager.py", line 268, in scan_models
    self.compiler = ModelCompiler(folder)
  File "/var/lib/inmanta/cf32fa4e-c9e3-41d9-a136-2e37c58c5b46/agent/env/lib/python3.9/site-packages/ncdiff/model.py", line 628, in __init__
    self.build_dependencies()
  File "/var/lib/inmanta/cf32fa4e-c9e3-41d9-a136-2e37c58c5b46/agent/env/lib/python3.9/site-packages/ncdiff/model.py", line 657, in build_dependencies
    from_cache = self._xml_from_cache("$dependencies")
  File "/var/lib/inmanta/cf32fa4e-c9e3-41d9-a136-2e37c58c5b46/agent/env/lib/python3.9/site-packages/ncdiff/model.py", line 635, in _xml_from_cache
    tree = etree.XML(fh.read(), parser)
  File "src/lxml/etree.pyx", line 3231, in lxml.etree.XML
  File "src/lxml/parser.pxi", line 1913, in lxml.etree._parseMemoryDocument
  File "src/lxml/parser.pxi", line 1793, in lxml.etree._parseDoc
  File "src/lxml/parser.pxi", line 1082, in lxml.etree._BaseParser._parseUnicodeDoc
  File "src/lxml/parser.pxi", line 615, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 725, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 654, in lxml.etree._raiseParseError
  File "<string>", line 1
lxml.etree.XMLSyntaxError: Document is empty, line 1, column 1
```
