### PR TITLE
Fix load_model for xml files

### DIFF
--- a/src/ncdiff/manager.py
+++ b/src/ncdiff/manager.py
@@ -307,6 +307,7 @@ class ModelDevice(manager.Manager):
                     xml = f.read()
                 parser = etree.XMLParser(remove_blank_text=True)
                 tree = etree.XML(xml, parser)
+                m = Model(tree)
             else:
                 raise ValueError("'{}' is not a file with extension 'xml'" \
                                  .format(model))


### PR DESCRIPTION
The method `ModelDevice.load_model` can take in argument a path to a compiled xml file.  But when such value is provided, the method doesn't build the actual Model object and doesn't assign it to the `m` variable, leading to a failure when checking if the model was previously loaded already.

```
Traceback (most recent call last):
  File "/home/guillaume/.virtualenvs/yang/lib/python3.9/site-packages/inmanta/agent/handler.py", line 896, in execute
    changes = self.calculate_diff(ctx, current, desired)
  File "/home/guillaume/Documents/cbci-dev/libs/yang/plugins/timer.py", line 106, in wrapper
    return func(_, ctx, *args, **kwargs)
  File "/home/guillaume/Documents/cbci-dev/libs/yang/plugins/gnmi/handler.py", line 146, in calculate_diff
    model_device.load_model(compiled_model)
  File "/home/guillaume/.virtualenvs/yang/lib/python3.9/site-packages/ncdiff/manager.py", line 322, in load_model
    "name or a compiled model xml file".format(model))
UnboundLocalError: local variable 'm' referenced before assignment
```

This MR fixes this.

(@wouterdb fyi)