### PR TITLE
fow monitor order does not matter

### DIFF
--- a/src/ncdiff/runningconfig.py
+++ b/src/ncdiff/runningconfig.py
@@ -25,6 +25,7 @@ SHORT_NO_COMMANDS = [
 ORDERLESS_COMMANDS = [
     r'^ *aaa authentication login ',
     r'^ *logging host ',
+    r'^ *flow monitor ',
 ]
 
 # Some commands can be overwritten without a no command. For example, changing

--- a/src/ncdiff/tests/test_running_config.py
+++ b/src/ncdiff/tests/test_running_config.py
@@ -562,3 +562,36 @@ logging host 10.200.159.168
         self.assertEqual(running_diff.diff_reverse, None)
         self.assertEqual(running_diff.cli, '')
         self.assertEqual(running_diff.cli_reverse, '')
+
+    def test_cli_flow_mon(self):
+        config_1 = """
+flow monitor eta-mon
+flow monitor meraki_monitor
+  exporter meraki_exporter
+  exporter customer_exporter
+  record meraki_record
+flow monitor meraki_monitor_ipv6
+  exporter meraki_exporter
+  exporter customer_exporter
+  record meraki_record_ipv6
+        """
+        config_2 = """
+flow monitor meraki_monitor
+  exporter meraki_exporter
+  exporter customer_exporter
+  record meraki_record
+flow monitor meraki_monitor_ipv6
+  exporter meraki_exporter
+  exporter customer_exporter
+  record meraki_record_ipv6
+flow monitor eta-mon
+        """
+        running_diff = RunningConfigDiff(
+            running1=config_1,
+            running2=config_2,
+        )
+        self.assertFalse(running_diff)
+        self.assertEqual(running_diff.diff, None)
+        self.assertEqual(running_diff.diff_reverse, None)
+        self.assertEqual(running_diff.cli, '')
+        self.assertEqual(running_diff.cli_reverse, '')


### PR DESCRIPTION
Flow monitor <WORD> order doesn't matter
961521:  - flow monitor eta-mon
961522:    flow monitor meraki_monitor
961523:      exporter meraki_exporter
961524:      exporter customer_exporter
961525:      record meraki_record
961526:    flow monitor meraki_monitor_ipv6
961527:      exporter meraki_exporter
961528:      exporter customer_exporter
961529:      record meraki_record_ipv6
961530:  + flow monitor eta-mon