### PR TITLE
Add new choice logic and unittests

### DIFF
--- a/src/ncdiff/netconf.py
+++ b/src/ncdiff/netconf.py
@@ -1001,7 +1001,7 @@ class NetconfCalculator(BaseCalculator):
                 # Append node if:
                 # Node not in case
                 # Node in case but choice node not in self
-                # Node in case and choice not in self but case also in self
+                # Node in case and choice node in self and the same case also in self
                 if s_node.getparent().get('type') == 'case':
                     choice_node = s_node.getparent().getparent()
                     if choice_node not in choice_nodes or \

--- a/src/ncdiff/tests/yang/jon.yang
+++ b/src/ncdiff/tests/yang/jon.yang
@@ -42,4 +42,43 @@ module jon {
     ordered-by user;
     default "Target";
   }
+
+  container location {
+    choice city {
+      case ontario {
+        list ontario {
+          key "name";
+          leaf name {
+            type string;
+          }
+        }
+      }
+      case alberta {
+        list alberta {
+          key "name";
+          leaf name {
+            type string;
+          }
+        }
+      }
+    }
+  }
+
+  container numbers {
+    choice number {
+      case one {
+        leaf first {
+          type string;
+        }
+      }
+      case two {
+        leaf second {
+          type string;
+        }
+        leaf third {
+          type string;
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
If config1 has a different case than config2, in edit-config remove deletion of case that is no longer being used.

Based on this:
Query regarding rfc6241 - 7.2 , same conceptual node and choice statement
https://mailarchive.ietf.org/arch/browse/netconf/