### PR TITLE
Sort indexes

### DIFF
--- a/src/ncdiff/runningconfig.py
+++ b/src/ncdiff/runningconfig.py
@@ -60,6 +60,7 @@ COEXIST_SHORT_POSITIVE_COMMANDS = [
 # depth are defined as "^ *exporter " and 1.
 ORDERLESS_COMMANDS = [
     (re.compile(r'^ *aaa authentication '), 0),
+    (re.compile(r'^ *aaa accounting system default '), 0),
     (re.compile(r'^ *aaa group server '), 0),
     (re.compile(r'^ *radius server '), 0),
     (re.compile(r'^ *logging host '), 0),
@@ -568,8 +569,7 @@ class RunningConfigDiff(object):
                     idx_positive_dict[exact_cmd] = idx_positive
 
         if idx_positive_list:
-            idx_positive_list.sort()
-            for idx in reversed(idx_positive_list):
+            for idx in sorted(idx_positive_list, reverse=True):
                 del positive_list[idx]
 
         # Handle duplicate commands
@@ -737,7 +737,7 @@ class RunningConfigDiff(object):
                 elif c1[:len(c2)] == c2:
                     indexes.add(idx1)
         if indexes:
-            for idx in reversed(list(indexes)):
+            for idx in sorted(indexes, reverse=True):
                 del negative_list[idx]
 
     @staticmethod
@@ -758,7 +758,7 @@ class RunningConfigDiff(object):
                 elif c1[:len(c2)] == c2:
                     indexes.add(idx2)
         if indexes:
-            for idx in reversed(list(indexes)):
+            for idx in sorted(indexes, reverse=True):
                 del positive_list[idx]
 
     def indent(self, str_in):

--- a/src/ncdiff/tests/test_running_config.py
+++ b/src/ncdiff/tests/test_running_config.py
@@ -1637,3 +1637,22 @@ mpls ldp advertise-labels for 32 to mpls
         self.assertEqual(running_diff.diff_reverse, None)
         self.assertEqual(running_diff.cli, '')
         self.assertEqual(running_diff.cli_reverse, '')
+
+    def test_aaa_accounting_system_default(self):
+        config_1 = """
+aaa accounting system default vrf vrf2 start-stop group RAD_Server
+aaa accounting system default vrf vrf1 start-stop group RAD_Server
+        """
+        config_2 = """
+aaa accounting system default vrf vrf1 start-stop group RAD_Server
+aaa accounting system default vrf vrf2 start-stop group RAD_Server
+        """
+        running_diff = RunningConfigDiff(
+            running1=config_1,
+            running2=config_2,
+        )
+        self.assertFalse(running_diff)
+        self.assertEqual(running_diff.diff, None)
+        self.assertEqual(running_diff.diff_reverse, None)
+        self.assertEqual(running_diff.cli, '')
+        self.assertEqual(running_diff.cli_reverse, '')


### PR DESCRIPTION
This PR fixes `indexes` which was not sorted. It also handles an orderless CLI:
```
25663: 2024-10-22T19:29:36: %TRANSACTION_LIB-3-ERROR:  FAILURE comparing to state Meraki-VRF-AAA 1, running-config needs changes:
25664: 2024-10-22T19:29:36: %TRANSACTION_LIB-3-ERROR:  - aaa accounting system default vrf vrf2 start-stop group RAD_Server
25665: 2024-10-22T19:29:36: %TRANSACTION_LIB-3-ERROR:    aaa accounting system default vrf vrf1 start-stop group RAD_Server
25666: 2024-10-22T19:29:36: %TRANSACTION_LIB-3-ERROR:  + aaa accounting system default vrf vrf2 start-stop group RAD_Server
```