### PR TITLE
Added an option to remove deprecated nodes or not

### DIFF
--- a/src/ncdiff/manager.py
+++ b/src/ncdiff/manager.py
@@ -1,10 +1,8 @@
 import os
 import re
 
-import six
 import logging
 from lxml import etree
-from copy import deepcopy
 from ncclient import manager, operations, transport, xml_
 from ncclient.devices.default import DefaultDeviceHandler
 
@@ -18,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 nc_url = xml_.BASE_NS_1_0
 yang_url = 'urn:ietf:params:xml:ns:yang:1'
-tailf_url= 'http://tail-f.com/ns/netconf/params/1.1'
+tailf_url = 'http://tail-f.com/ns/netconf/params/1.1'
 ncEvent_url = xml_.NETCONF_NOTIFICATION_NS
 config_tag = '{' + nc_url + '}config'
 filter_tag = '{' + nc_url + '}filter'
@@ -33,7 +31,8 @@ special_prefixes = {
 def connect(*args, **kwargs):
     """
     Initialize a :class:`ModelDevice` over the SSH transport.
-    For documentation of arguments see :meth:`ncclient.transport.SSHSession.connect`.
+    For documentation of arguments see
+    :meth:`ncclient.transport.SSHSession.connect`.
     The underlying :class:`ncclient.transport.SSHSession` is created with
         :data:`CAPABILITIES`. It is first instructed to
         :meth:`~ncclient.transport.SSHSession.load_known_hosts` and then
@@ -47,7 +46,7 @@ def connect(*args, **kwargs):
         session.load_known_hosts()
 
     try:
-       session.connect(*args, **kwargs)
+        session.connect(*args, **kwargs)
     except Exception as ex:
         if session.transport:
             session.close()
@@ -478,7 +477,7 @@ class ModelDevice(manager.Manager):
             reply.ns = self._get_ns(reply._root_ele)
         return reply
 
-    def extract_config(self, reply, type='netconf'):
+    def extract_config(self, reply, type='netconf', remove_deprecated=False):
         '''extract_config
 
         High-level api: Extract config from a rpc-reply of get-config or get
@@ -523,9 +522,9 @@ class ModelDevice(manager.Manager):
                 elif len(child) > 0:
                     remove_read_only(child)
 
-        config = Config(self, reply)
+        config = Config(self, reply, validate=True,
+                        remove_deprecated=remove_deprecated)
         remove_read_only(config.ele)
-        config.validate_config()
         return config
 
     def get_schema_node(self, config_node):

--- a/src/ncdiff/tests/test_ncdiff.py
+++ b/src/ncdiff/tests/test_ncdiff.py
@@ -3451,3 +3451,105 @@ class TestNcDiff(unittest.TestCase):
                        '/oc-netinst:config/oc-netinst:name/text()')
         self.assertEqual(name, ['Mgmt-intf'])
 
+    def test_extract_config_1(self):
+        config_xml = """
+            <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+              <data>
+                <foo xmlns="urn:jon">abc</foo>
+                <tracking xmlns="urn:jon">
+                  <enabled>true</enabled>
+                </tracking>
+                <address xmlns="urn:jon">
+                  <last>Brown</last>
+                  <first>Bob</first>
+                  <street>Innovation</street>
+                  <city>New York</city>
+                  <city-v2>New York</city-v2>
+                </address>
+                <address xmlns="urn:jon">
+                  <last>Paul</last>
+                  <first>Bob</first>
+                  <street>Express</street>
+                  <city>Kanata</city>
+                  <city-v2>Kanata</city-v2>
+                </address>
+                <address xmlns="urn:jon">
+                  <last>Wang</last>
+                  <first>Ken</first>
+                  <street>Main</street>
+                  <city>Boston</city>
+                  <city-v2>Boston</city-v2>
+                </address>
+                <store xmlns="urn:jon">Dollar</store>
+                <store xmlns="urn:jon">Cheap</store>
+                <store xmlns="urn:jon">Quick</store>
+              </data>
+            </rpc-reply>
+            """
+        config = self.d.extract_config(
+            config_xml,
+            remove_deprecated=False,
+        )
+        nodes = config.xpath(
+            '/nc:config/jon:address[jon:last="Brown"][jon:first="Bob"]'
+            '/jon:city/text()'
+        )
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0], 'New York')
+        nodes = config.xpath(
+            '/nc:config/jon:address[jon:last="Brown"][jon:first="Bob"]'
+            '/jon:city-v2/text()'
+        )
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0], 'New York')
+
+    def test_extract_config_2(self):
+        config_xml = """
+            <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
+              <data>
+                <foo xmlns="urn:jon">abc</foo>
+                <tracking xmlns="urn:jon">
+                  <enabled>true</enabled>
+                </tracking>
+                <address xmlns="urn:jon">
+                  <last>Brown</last>
+                  <first>Bob</first>
+                  <street>Innovation</street>
+                  <city>New York</city>
+                  <city-v2>New York</city-v2>
+                </address>
+                <address xmlns="urn:jon">
+                  <last>Paul</last>
+                  <first>Bob</first>
+                  <street>Express</street>
+                  <city>Kanata</city>
+                  <city-v2>Kanata</city-v2>
+                </address>
+                <address xmlns="urn:jon">
+                  <last>Wang</last>
+                  <first>Ken</first>
+                  <street>Main</street>
+                  <city>Boston</city>
+                  <city-v2>Boston</city-v2>
+                </address>
+                <store xmlns="urn:jon">Dollar</store>
+                <store xmlns="urn:jon">Cheap</store>
+                <store xmlns="urn:jon">Quick</store>
+              </data>
+            </rpc-reply>
+            """
+        config = self.d.extract_config(
+            config_xml,
+            remove_deprecated=True,
+        )
+        nodes = config.xpath(
+            '/nc:config/jon:address[jon:last="Brown"][jon:first="Bob"]'
+            '/jon:city/text()'
+        )
+        self.assertEqual(len(nodes), 0)
+        nodes = config.xpath(
+            '/nc:config/jon:address[jon:last="Brown"][jon:first="Bob"]'
+            '/jon:city-v2/text()'
+        )
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0], 'New York')

--- a/src/ncdiff/tests/yang/jon.yang
+++ b/src/ncdiff/tests/yang/jon.yang
@@ -7,6 +7,11 @@ module jon {
       "Initial revision";
   }
 
+  revision 2025-04-02 {
+    description
+      "Deprecated two nodes";
+  }
+
   leaf foo {
     type string;
   }
@@ -14,6 +19,24 @@ module jon {
   container tracking {
     leaf enabled {
       type boolean;
+      default "false"; /* Deprecated, use 'enabled-v2' instead */
+      status deprecated; /* Marked as deprecated in the 2025-04-02 revision */
+    }
+    leaf enabled-v2 {
+      type boolean;
+    }
+    container logging {
+      leaf local {
+        type boolean;
+      }
+      container server {
+        leaf host {
+          type string;
+        }
+        leaf port {
+          type uint16;
+        }
+      }
     }
   }
 
@@ -33,6 +56,12 @@ module jon {
       description "Street name";
     }
     leaf city {
+      type string;
+      description "City name";
+      default "Unknown"; /* Deprecated, use 'city-v2' instead */
+      status deprecated; /* Marked as deprecated in the 2025-04-02 revision */
+    }
+    leaf city-v2 {
       type string;
       description "City name";
     }


### PR DESCRIPTION
Adding an option in `extract_config()` to remove deprecated nodes. By default, deprecated nodes should stay, which is in compliance with RFC7950.