### PR TITLE
Coexist CLIs and changes in handling "create" operation

### DIFF
--- a/src/ncdiff/netconf.py
+++ b/src/ncdiff/netconf.py
@@ -1263,8 +1263,13 @@ class NetconfCalculator(BaseCalculator):
             schema_node.get('type') == 'container' and
             schema_node.get('presence') != 'true'
         ):
+            default_xpaths = [self.device.get_xpath(n)
+                              for n in self.device.default_in_use(schema_node)]
             for child in node:
-                self.set_create_operation(child)
+                child_xpath = self.device.get_xpath(
+                    self.device.get_schema_node(child))
+                if child_xpath not in default_xpaths:
+                    self.set_create_operation(child)
         else:
             node.set(operation_tag, 'create')
 

--- a/src/ncdiff/runningconfig.py
+++ b/src/ncdiff/runningconfig.py
@@ -31,6 +31,8 @@ SHORT_NO_COMMANDS = [
 # These cases can be recorded here.
 COEXIST_SHORT_POSITIVE_COMMANDS = [
     'snmp-server manager',
+    'ip multicast-routing',
+    'ip dhcp relay information option',
 ]
 
 # Some commands are orderless, e.g., "show running-config" output could be:

--- a/src/ncdiff/tests/test_running_config.py
+++ b/src/ncdiff/tests/test_running_config.py
@@ -1836,3 +1836,52 @@ netconf-yang
         self.assertEqual(running_diff.diff_reverse, None)
         self.assertEqual(running_diff.cli, '')
         self.assertEqual(running_diff.cli_reverse, '')
+
+    def test_coexist_short_positive_commands_1(self):
+        config_1 = """
+ip routing
+!
+        """
+        config_2 = """
+ip routing
+!
+ip multicast-routing
+ip multicast-routing vrf green
+ip multicast-routing vrf blue
+        """
+        expected_lines = [
+            'ip multicast-routing',
+            'ip multicast-routing vrf blue',
+            'ip multicast-routing vrf green',
+        ]
+        running_diff = RunningConfigDiff(
+            running1=config_1,
+            running2=config_2,
+        )
+        clis = running_diff.cli.splitlines()
+        for expected_line in expected_lines:
+            self.assertIn(expected_line, clis,
+                          f'CLI "{expected_line}" is missing')
+
+    def test_coexist_short_positive_commands_2(self):
+        config_1 = """
+ip domain name cisco.com
+!
+        """
+        config_2 = """
+ip domain name cisco.com
+ip dhcp relay information option vpn
+ip dhcp relay information option
+        """
+        expected_lines = [
+            'ip dhcp relay information option vpn',
+            'ip dhcp relay information option',
+        ]
+        running_diff = RunningConfigDiff(
+            running1=config_1,
+            running2=config_2,
+        )
+        clis = running_diff.cli.splitlines()
+        for expected_line in expected_lines:
+            self.assertIn(expected_line, clis,
+                          f'CLI "{expected_line}" is missing')


### PR DESCRIPTION
This PR has two pieces of update. The first piece is adding more coexist CLIs. For example, `ip multicast-routing` and `ip multicast-routing vrf blue` can coexist.

The second piece is an enhancement in handling "create" operation. If a parent is a non-presence container and a child has a default value in use, it is not allowed to put "create" operation on the child. The child should be treated as it already exists.

Unit tests are added.

```
(pyats-2401) [yuekyang@yangtest-lnx tests]$ python -m unittest test_ncdiff
Error in Netconf reply when getting /netconf-state/schemas from YANG module 'ietf-netconf-monitoring':
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <rpc-error>
    <error-type>rpc</error-type>
    <error-tag>missing-attribute</error-tag>
    <error-severity>error</error-severity>
    <error-info>
      <bad-attribute>message-id</bad-attribute>
      <bad-element>rpc</bad-element>
    </error-info>
  </rpc-error>
</rpc-reply>

Error in Netconf reply when getting /modules-state/module from YANG module 'ietf-yang-library':
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <rpc-error>
    <error-type>rpc</error-type>
    <error-tag>missing-attribute</error-tag>
    <error-severity>error</error-severity>
    <error-info>
      <bad-attribute>message-id</bad-attribute>
      <bad-element>rpc</bad-element>
    </error-info>
  </rpc-error>
</rpc-reply>

..........................................
----------------------------------------------------------------------
Ran 42 tests in 0.559s

OK
(pyats-2401) [yuekyang@yangtest-lnx tests]$ python -m unittest test_running_config
...............................................
----------------------------------------------------------------------
Ran 47 tests in 0.031s

OK
(pyats-2401) [yuekyang@yangtest-lnx tests]$
```