### PR TITLE
Operation "delete" on NP containers

### DIFF
--- a/src/ncdiff/runningconfig.py
+++ b/src/ncdiff/runningconfig.py
@@ -126,6 +126,7 @@ ORDERLESS_COMMANDS = [
     (re.compile(r'^ *device-tracking binding '), 0),
     (re.compile(r'^ *netconf-yang'), 0),
     (re.compile(r'^ *summary-address '), 1),
+    (re.compile(r'^ *member vni '), 1),
 ]
 
 # Some commands can be overwritten without a no command. For example, changing


### PR DESCRIPTION
Delete operation on non-presence containers is allowed even there is nothing inside the non-presence container as per ConfD implementation although the expected behavior is ambiguous in RFC7950. More discussion can be found in the Tail-F ticket PS-47089.
In negative testing case, if we want the delete operation to be rejected when there is nothing inside the non-presence container, we have to put delete operations on the descendants of the non-presence container, which are not non-presence containers.
All unit tests passed:
```
(pyats-2401) [yuekyang@yangtest-lnx tests]$ python -m unittest test_ncdiff
Error in Netconf reply when getting /netconf-state/schemas from YANG module 'ietf-netconf-monitoring':
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <rpc-error>
    <error-type>rpc</error-type>
    <error-tag>missing-attribute</error-tag>
    <error-severity>error</error-severity>
    <error-info>
      <bad-attribute>message-id</bad-attribute>
      <bad-element>rpc</bad-element>
    </error-info>
  </rpc-error>
</rpc-reply>

Error in Netconf reply when getting /modules-state/module from YANG module 'ietf-yang-library':
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
  <rpc-error>
    <error-type>rpc</error-type>
    <error-tag>missing-attribute</error-tag>
    <error-severity>error</error-severity>
    <error-info>
      <bad-attribute>message-id</bad-attribute>
      <bad-element>rpc</bad-element>
    </error-info>
  </rpc-error>
</rpc-reply>

...........................................
----------------------------------------------------------------------
Ran 43 tests in 0.591s

OK
```
