### PR TITLE
no-match in class-map

### DIFF
--- a/src/ncdiff/runningconfig.py
+++ b/src/ncdiff/runningconfig.py
@@ -78,6 +78,7 @@ ORDERLESS_COMMANDS = [
     (re.compile(r'^ *username '), 0),
     (re.compile(r'^ *parameter-map type '), 0),
     (re.compile(r'^ *match '), 1),
+    (re.compile(r'^ *no-match '), 1),
     (re.compile(r'^ *collect connection '), 1),
     (re.compile(r'^ *l2nat instance '), 0),
     (re.compile(r'^ *inside from host '), 1),

--- a/src/ncdiff/tests/test_running_config.py
+++ b/src/ncdiff/tests/test_running_config.py
@@ -2115,10 +2115,6 @@ class-map match-any CM_Q_SET
     def test_classmap_match_result_type(self):
         config_1 = """
 class-map type control subscriber match-all CM_CTRL
- match activated-service-template ST_CTRL_A
- match authorization-status authorized
- match device-type "CAMERA"
- match device-type regex "PHONE"
  match method dot1x
  match method mab
  match result-type aaa-timeout
@@ -2128,8 +2124,12 @@ class-map type control subscriber match-all CM_CTRL
  match result-type method dot1x method-timeout
  match result-type method mab aaa-timeout
  match result-type method mab authoritative
- no-match activated-service-template ST_CTRL_B
  no-match result-type aaa-timeout
+ match activated-service-template ST_CTRL_A
+ match authorization-status authorized
+ match device-type regex "PHONE"
+ match device-type "CAMERA"
+ no-match activated-service-template ST_CTRL_B
         """
         config_2 = """
 class-map type control subscriber match-all CM_CTRL


### PR DESCRIPTION
Another orderless CLI in `class-map`.

Unit tests passed:
```
(pyats-2507) [yuekyang@rtp-ads-1239 tests]$ python -m unittest test_running_config.py
.........................................................
----------------------------------------------------------------------
Ran 57 tests in 0.027s

OK
```